### PR TITLE
FIX error vendor/autoload.php from composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,9 @@
 	"support": {
 		"issues": "https://github.com/OOPS-ORG-PHP/mysql-extension-wrapper/issues"
 	},
+	"autoload": {
+            "files": ["mysql-wrapper.php"]
+        },
 	"require": {
 		"php": ">=4.1.0",
 		"ext-mysqli": "*"


### PR DESCRIPTION
It's a simple fix, but with this works fine, now you need do this:

// Composer loader
require_once "vendor/autoload.php";

// FIX error package warper of old mysql with library version 1.0.0
if (!function_exists("mysql_connect"))
{
    require_once "vendor/joungkyun/mysql-extension-wrapper/mysql-wrapper.php";
}