### PR TITLE
fixed #3 fixed typo 'calassname' to 'classname'

### DIFF
--- a/mysql-wrapper.php
+++ b/mysql-wrapper.php
@@ -486,9 +486,9 @@ function mysql_fetch_object ($result, $classname = null, $params = null) {
 				);
 				return false;
 			}
-			$r = mysqli_fetch_object ($result, $calassname, $params);
+			$r = mysqli_fetch_object ($result, $classname, $params);
 		} else
-			$r = mysqli_fetch_object ($result, $calassname);
+			$r = mysqli_fetch_object ($result, $classname);
 	} else
 		$r = mysqli_fetch_object ($result);
 


### PR DESCRIPTION
reference: #3 

Fixed an issue where classname is not handled due to typo when using the third factor classname of mysql_fetch_object.